### PR TITLE
some fixes

### DIFF
--- a/content/all_frames.js
+++ b/content/all_frames.js
@@ -16,8 +16,17 @@ window.addEventListener("click", async (event) => {
 
   if (event.target.matches("input[type=file]:not([webkitdirectory])")) {
     target = event.target;
-  } else if (event.originalTarget.matches("input[type=file]:not([webkitdirectory])")) {
-    target = event.originalTarget;
+  } else {
+    try {
+      // try do "toString()" because Firefox can disallow read "originalTarget" property
+      new String(event.originalTarget);
+
+      if (event.originalTarget.matches("input[type=file]:not([webkitdirectory])")) {
+        target = event.originalTarget;
+      }
+    } catch  {
+        // permission denied
+    }
   }
 
   if (target) {
@@ -71,8 +80,9 @@ exportFunction(
   function (event) {
     if (event.type === "click" && this.matches("[type=file]:not([webkitdirectory])")) {
       handleInputElement(this);
+      return true;
     } else {
-      this.dispatchEvent(event);
+      return this.dispatchEvent(event);
     }
   },
   HTMLInputElement.prototype,

--- a/content/all_frames.js
+++ b/content/all_frames.js
@@ -18,14 +18,11 @@ window.addEventListener("click", async (event) => {
     target = event.target;
   } else {
     try {
-      // try do "toString()" because Firefox can disallow read "originalTarget" property
-      new String(event.originalTarget);
-
       if (event.originalTarget.matches("input[type=file]:not([webkitdirectory])")) {
         target = event.originalTarget;
       }
     } catch  {
-        // permission denied
+        // permission denied to read "originalTarget" property
     }
   }
 


### PR DESCRIPTION
This PR fixes two bugs:
1. [Awesomplete](https://github.com/LeaVerou/awesomplete) does not work if **dispatchEvent()** returns `undefined`. see [EventTarget: dispatchEvent() method](https://developer.mozilla.org/docs/Web/API/EventTarget/dispatchEvent).
2. reading `event.originalTarget` can be denied if firefox **Enhanced Tracking Protection** is enforced:
![imagen](https://user-images.githubusercontent.com/16857233/231034843-ba2365c6-5136-4b86-ac94-f091ef760e26.png)
