### PR TITLE
Add gif support

### DIFF
--- a/background/background.js
+++ b/background/background.js
@@ -102,12 +102,23 @@ browser.runtime.onConnect.addListener(port => {
           let blob = null;
           let blobType = null;
 
-          const img = items.find(i => i.types.includes("image/png"));
+          const supportedImageTypes = [
+            "image/png",
+            "image/jpeg",
+            "image/gif",
+          ];
+
+          const img = items.find(i =>
+            supportedImageTypes.some(t => i.types.includes(t))
+          );
 
           if (img && (await getSetting("enableImagePaste"))) {
-            const imgBlob = await img.getType("image/png");
+            const imgType = supportedImageTypes.find(t =>
+              img.types.includes(t)
+            );
+            const imgBlob = await img.getType(imgType);
             if (imgBlob.size > 0) {
-              blob = await img.getType("image/png");
+              blob = imgBlob;
               blobType = "image";
             }
           }

--- a/popup/popup.css
+++ b/popup/popup.css
@@ -84,8 +84,7 @@ button {
       content: ".png";
     }
 
-    #formatToggle span::after,
-    #floatingFormatToggle span::after {
+    #formatToggle span::after {
       content: "PNG";
     }
   }
@@ -95,9 +94,18 @@ button {
       content: ".jpg";
     }
 
-    #formatToggle span::after,
-    #floatingFormatToggle span::after {
+    #formatToggle span::after {
       content: "JPG";
+    }
+  }
+
+  &[data-format="gif"] {
+    #filename::after {
+      content: ".gif";
+    }
+
+    #formatToggle span::after {
+      content: "GIF";
     }
   }
 }
@@ -205,8 +213,7 @@ button {
   }
 }
 
-#formatToggle,
-#floatingFormatToggle {
+#formatToggle {
   display: flex;
   flex: 0 0 auto;
   justify-content: center;
@@ -219,6 +226,13 @@ button {
   text-transform: uppercase;
   box-shadow: 0 0 calc(4px / var(--devicePixelRatio))
     light-dark(transparent, rgba(0, 0, 0, 0.5));
+  min-width: calc(42px / var(--devicePixelRatio));
+  min-height: calc(24px / var(--devicePixelRatio));
+  margin-inline-start: calc(6px / var(--devicePixelRatio));
+  margin-inline-end: calc(8px / var(--devicePixelRatio));
+  font-size: calc(12px / var(--devicePixelRatio));
+  background-color: var(--toggle-bg);
+  border-radius: calc(4px / var(--devicePixelRatio));
 
   span {
     pointer-events: none;
@@ -232,42 +246,9 @@ button {
     outline: calc(2px / var(--devicePixelRatio)) solid var(--button-bg);
     outline-offset: 0px;
   }
-}
-
-#formatToggle {
-  min-width: calc(42px / var(--devicePixelRatio));
-  min-height: calc(24px / var(--devicePixelRatio));
-  margin-inline-start: calc(6px / var(--devicePixelRatio));
-  margin-inline-end: calc(8px / var(--devicePixelRatio));
-  font-size: calc(12px / var(--devicePixelRatio));
-  background-color: var(--toggle-bg);
-  border-radius: calc(4px / var(--devicePixelRatio));
 
   &:hover {
     background-color: var(--toggle-bg-hover);
-  }
-}
-
-#floatingFormatToggle {
-  position: absolute;
-  top: calc(12px / var(--devicePixelRatio));
-  right: calc(12px / var(--devicePixelRatio));
-  min-width: calc(46px / var(--devicePixelRatio));
-  font-size: calc(13px / var(--devicePixelRatio));
-  background-color: var(--floating-toggle-bg);
-  border: calc(1px / var(--devicePixelRatio)) solid
-    var(--floating-toggle-border);
-  border-radius: calc(4px / var(--devicePixelRatio));
-
-  &::after {
-    content: "";
-    position: absolute;
-    inset: calc(-6px / var(--devicePixelRatio));
-  }
-
-  &:hover {
-    background-color: var(--floating-toggle-bg-hover);
-    border-color: var(--floating-toggle-border-hover);
   }
 }
 
@@ -290,5 +271,66 @@ button {
   &:focus-visible {
     outline: calc(2px / var(--devicePixelRatio)) solid var(--button-bg);
     outline-offset: calc(2px / var(--devicePixelRatio));
+  }
+}
+
+&[data-format="gif"] {
+  #filename::after {
+    content: ".gif";
+  }
+
+  #formatToggle span::after,
+  #floatingFormatToggle span::after {
+    content: "GIF";
+  }
+}
+
+#formatPopover {
+  position: absolute;
+  top: calc(100% + 4px / var(--devicePixelRatio));
+  top: calc(24px * 2 / var(--devicePixelRatio));
+  right: 0;
+  display: flex;
+  flex-direction: column;
+  gap: calc(2px / var(--devicePixelRatio));
+  padding: calc(4px / var(--devicePixelRatio));
+  background-color: var(--popup-bg);
+  border: calc(1px / var(--devicePixelRatio)) solid var(--popup-border);
+  border-radius: calc(6px / var(--devicePixelRatio));
+  box-shadow: 0 calc(4px / var(--devicePixelRatio))
+    calc(12px / var(--devicePixelRatio)) var(--popup-shadow);
+  z-index: 10;
+
+  &[hidden] {
+    display: none !important;
+  }
+}
+
+.format-option {
+  display: block;
+  width: 100%;
+  min-width: calc(52px / var(--devicePixelRatio));
+  padding-block: calc(5px / var(--devicePixelRatio));
+  padding-inline: calc(10px / var(--devicePixelRatio));
+  font-size: calc(12px / var(--devicePixelRatio));
+  font-weight: 600;
+  text-align: center;
+  text-transform: uppercase;
+  color: var(--toggle-text);
+  background-color: transparent;
+  border-radius: calc(3px / var(--devicePixelRatio));
+  cursor: pointer;
+
+  &:hover {
+    background-color: var(--toggle-bg-hover);
+  }
+
+  &[aria-checked="true"] {
+    background-color: var(--toggle-bg);
+  }
+
+  &:focus-visible {
+    outline: calc(2px / var(--devicePixelRatio)) solid var(--button-bg);
+    outline-offset: 0;
   }
 }

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -16,10 +16,13 @@
         <button id="formatToggle" type="button" hidden>
           <span></span>
         </button>
+        <div id="formatPopover" role="menu" hidden>
+          <button class="format-option" data-format="png" role="menuitem">PNG</button>
+          <button class="format-option" data-format="jpeg" role="menuitem">JPG</button>
+          <button class="format-option" data-format="gif" role="menuitem">GIF</button>
+        </div>
       </div>
-      <button id="floatingFormatToggle" type="button" hidden>
-        <span></span>
-      </button>
+
       <button id="preview">
         <img tabindex="-1" id="imagePreview" draggable="false" />
         <div tabindex="-1" id="textPreview" hidden></div>

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -54,7 +54,8 @@ const popup = document.getElementById("popup");
 const filenameContainer = document.getElementById("filenameContainer");
 const filenameInput = document.getElementById("filename");
 const formatToggle = document.getElementById("formatToggle");
-const floatingFormatToggle = document.getElementById("floatingFormatToggle");
+const formatPopover = document.getElementById("formatPopover");
+const formatOptions = document.querySelectorAll(".format-option");
 const preview = document.getElementById("preview");
 const imagePreview = document.getElementById("imagePreview");
 const textPreview = document.getElementById("textPreview");
@@ -98,8 +99,14 @@ const computeFinalFilename = () => {
     return input.length === 0 ? `${baseName}.${textExtension}` : baseName;
   }
 
-  const ext = currentFormat === "jpeg" ? ".jpg" : ".png";
-  return baseName.replace(/\.(png|jpg|jpeg)$/i, "") + ext;
+  const extensionMap = {
+    jpeg: ".jpg",
+    png: ".png",
+    gif: ".gif",
+  };
+
+  const ext = extensionMap[currentFormat] || ".png";
+  return baseName.replace(/\.(png|jpg|jpeg|gif)$/i, "") + ext;
 };
 
 const updatePreview = () => {
@@ -137,11 +144,20 @@ const setFileType = async (type, saveToStorage = false) => {
 
     if (type === "jpeg") {
       currentBlob = await convertToJpeg(originalBlob, jpegQuality);
+    } else if (type === "gif") {
+      currentBlob = await convertToGif(originalBlob);
     } else {
       currentBlob = originalBlob;
     }
 
     updatePreview();
+
+    for (const opt of formatOptions) {
+      opt.setAttribute(
+        "aria-checked",
+        opt.dataset.format === type ? "true" : "false"
+      );
+    }
 
     if (saveToStorage) {
       browser.storage.local.set({ defaultFileType: type });
@@ -194,11 +210,7 @@ if (showFilenameBox) {
 }
 
 if (settings.showFormatToggleButton && clipboardType === "image") {
-  if (showFilenameBox) {
-    formatToggle.hidden = false;
-  } else {
-    floatingFormatToggle.hidden = false;
-  }
+  formatToggle.hidden = false;
 }
 
 showAllFiles.textContent = browser.i18n.getMessage("showAllFiles");
@@ -284,24 +296,23 @@ const handleEnter = e => {
 filenameInput.addEventListener("keydown", handleEnter);
 textPreview.addEventListener("keydown", handleEnter);
 
-const handleFormatToggle = async e => {
-  e.preventDefault();
-  if (
-    e.button === 2 ||
-    (e.type === "click" && e.mozInputSource === MouseEvent.MOZ_SOURCE_MOUSE)
-  ) {
-    return;
-  }
-
-  const newType = currentFormat === "jpeg" ? "png" : "jpeg";
-  await setFileType(newType, true);
-};
-
 if (clipboardType === "image") {
-  formatToggle.addEventListener("mousedown", handleFormatToggle);
-  floatingFormatToggle.addEventListener("mousedown", handleFormatToggle);
-  formatToggle.addEventListener("click", handleFormatToggle);
-  floatingFormatToggle.addEventListener("click", handleFormatToggle);
+  formatToggle.addEventListener("mousedown", e => {
+    e.preventDefault();
+  });
+
+  formatToggle.addEventListener("click", e => {
+    formatPopover.hidden = !formatPopover.hidden;
+  });
+
+  for (const opt of formatOptions) {
+    opt.addEventListener("click", async e => {
+      e.stopPropagation();
+      const fmt = e.currentTarget.dataset.format;
+      await setFileType(fmt, true);
+      formatPopover.hidden = true;
+    });
+  }
 }
 
 preview.addEventListener(
@@ -423,6 +434,14 @@ async function convertToJpeg(blob, quality) {
     type: "image/jpeg",
     quality: quality,
   });
+}
+
+async function convertToGif(blob) {
+  if (blob.type === "image/gif") {
+    return blob;
+  }
+
+  return new Blob([await blob.arrayBuffer()], { type: "image/gif" });
 }
 
 function showPicker(inputAttributes) {

--- a/settings/options.js
+++ b/settings/options.js
@@ -245,7 +245,7 @@ function createCustomInput(container, item, settings) {
   const saveInput = async () => {
     let val = input.value.trim();
     if (item.key === "customFilenameImage")
-      val = val.replace(/\.(png|jpg|jpeg)$/i, "");
+      val = val.replace(/\.(png|jpg|jpeg|gif)$/i, "");
     else if (item.key === "textExtension") val = val.replace(/^\./, "");
 
     val = val.trim();
@@ -329,8 +329,15 @@ async function refreshUI() {
 
   const extSpanImage = document.getElementById("ext-customFilenameImage");
   if (extSpanImage) {
-    extSpanImage.textContent =
-      settings["defaultFileType"] === "jpeg" ? ".jpg" : ".png";
+    const fileType = settings["defaultFileType"];
+
+    const extensionMap = {
+      jpeg: ".jpg",
+      png: ".png",
+      gif: ".gif",
+    };
+
+    extSpanImage.textContent = extensionMap[fileType] || ".png";
   }
   const extSpanText = document.getElementById("ext-customFilenameText");
   if (extSpanText) {

--- a/settings/settings.js
+++ b/settings/settings.js
@@ -53,6 +53,7 @@ export const options = [
     options: [
       { value: "png", text: "PNG" },
       { value: "jpeg", text: "JPG" },
+      { value: "gif", text: "GIF" },
     ],
   },
   {


### PR DESCRIPTION
Fixes https://github.com/clipboard2file/clipboard2file/issues/31
Seems to work for me on Firefox v151. 

It's also worth mentioning that Firefox by default copies the current frame from GIF as PNG instead of copying the file. There's a flag `clipboard.imageAsFile.enabled`, but by looking at the [source code](https://searchfox.org/firefox-main/rev/8332a06d47ce7d66623d807068b3410061cd29d3/modules/libpref/init/StaticPrefList.yaml#2256), it seems like it's only working for Windows, so I was using `xclip` instead on Linux while testing the PR.